### PR TITLE
refactor(types): add explicit TypeScript return types

### DIFF
--- a/data/headerNavLinks.ts
+++ b/data/headerNavLinks.ts
@@ -1,4 +1,9 @@
-const headerNavLinks = [
+export interface NavLink {
+  href: string
+  title: string
+}
+
+const headerNavLinks: NavLink[] = [
   { href: '/', title: 'Home' },
   { href: '/projects', title: 'Projects' },
   { href: '/blog', title: 'Blog' },

--- a/lib/preferences/PreferencesService.ts
+++ b/lib/preferences/PreferencesService.ts
@@ -1,9 +1,9 @@
 export const PreferencesService = {
-  getPref(key: 'theme' | 'lang') {
+  getPref(key: 'theme' | 'lang'): string | null {
     if (typeof window === 'undefined') return null
     return localStorage.getItem(`lightstimulus.${key}`)
   },
-  setPref(key: 'theme' | 'lang', value: string) {
+  setPref(key: 'theme' | 'lang', value: string): void {
     if (typeof window === 'undefined') return
     localStorage.setItem(`lightstimulus.${key}`, value)
   },

--- a/utils/detectRefreshOrFirstLoad.ts
+++ b/utils/detectRefreshOrFirstLoad.ts
@@ -1,4 +1,4 @@
-export function detectRefreshOrFirstLoad(key: string) {
+export function detectRefreshOrFirstLoad(key: string): boolean {
   const prev = sessionStorage.getItem(key)
   const now = Date.now()
 


### PR DESCRIPTION
Add explicit return type annotations to improve type safety:
- PreferencesService: string | null and void return types
- detectRefreshOrFirstLoad: boolean return type
- headerNavLinks: NavLink interface with typed array