### PR TITLE
feat(contact): add bilingual netlify contact form

### DIFF
--- a/app/contact/page.tsx
+++ b/app/contact/page.tsx
@@ -1,5 +1,6 @@
 import SectionContainer from '@/components/SectionContainer'
 import { ContactIntro } from '@/components/contact/ContactIntro'
+import { ContactForm } from '@/components/contact/ContactForm'
 import { ContactMethods } from '@/components/contact/ContactMethods'
 import { allAuthors } from 'contentlayer/generated'
 import { genPageMetadata } from '@/app/seo'
@@ -17,6 +18,8 @@ export default function ContactPage() {
     <SectionContainer>
       <section className="pt-10 pb-16">
         <ContactIntro />
+
+        <ContactForm />
 
         <ContactMethods email={author?.email} linkedin={author?.linkedin} />
       </section>

--- a/components/contact/ContactForm.tsx
+++ b/components/contact/ContactForm.tsx
@@ -1,0 +1,237 @@
+'use client'
+
+import { useState } from 'react'
+import { useLanguage } from '@/contexts/LanguageContext'
+
+/** Netlify form name — must match public/__forms.html and the AJAX body. */
+const FORM_NAME = 'contact'
+
+/** Basic email format check (intentionally permissive). */
+const EMAIL_RE = /^\S+@\S+\.\S+$/
+
+type FieldName = 'name' | 'email' | 'message'
+type SubmitStatus = 'idle' | 'submitting' | 'success' | 'error'
+type FieldErrors = Partial<Record<FieldName, string>>
+
+const shared =
+  'w-full rounded-lg border border-white/30 bg-white/60 px-3 py-2 text-sm text-gray-800 shadow-sm placeholder:text-gray-400 focus:border-[var(--color-primary-500)] focus:ring-2 focus:ring-[var(--color-primary-500)] focus:outline-none dark:border-white/10 dark:bg-white/5 dark:text-gray-100 dark:placeholder:text-gray-500'
+
+const invalidRing = 'border-red-400 focus:border-red-500 focus:ring-red-500 dark:border-red-500/70'
+
+export function ContactForm() {
+  const { t } = useLanguage()
+
+  const [values, setValues] = useState({ name: '', email: '', message: '' })
+  const [errors, setErrors] = useState<FieldErrors>({})
+  const [status, setStatus] = useState<SubmitStatus>('idle')
+
+  const validateField = (field: FieldName, raw: string): string | undefined => {
+    const value = raw.trim()
+    switch (field) {
+      case 'name':
+        if (!value) return t('contact.form.errors.name_required')
+        return undefined
+      case 'email':
+        if (!value) return t('contact.form.errors.email_required')
+        if (!EMAIL_RE.test(value)) return t('contact.form.errors.email_invalid')
+        return undefined
+      case 'message':
+        if (!value) return t('contact.form.errors.message_required')
+        if (value.length < 10) return t('contact.form.errors.message_too_short')
+        return undefined
+    }
+  }
+
+  const validateAll = (): FieldErrors => {
+    const next: FieldErrors = {}
+    ;(Object.keys(values) as FieldName[]).forEach((field) => {
+      const err = validateField(field, values[field])
+      if (err) next[field] = err
+    })
+    return next
+  }
+
+  const handleChange =
+    (field: FieldName) => (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
+      setValues((prev) => ({ ...prev, [field]: e.target.value }))
+      // Clear an existing error as the user corrects the field.
+      setErrors((prev) => (prev[field] ? { ...prev, [field]: undefined } : prev))
+    }
+
+  const handleBlur = (field: FieldName) => () => {
+    const err = validateField(field, values[field])
+    setErrors((prev) => ({ ...prev, [field]: err }))
+  }
+
+  const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault()
+    if (status === 'submitting') return
+
+    const nextErrors = validateAll()
+    setErrors(nextErrors)
+    if (Object.values(nextErrors).some(Boolean)) return
+
+    setStatus('submitting')
+
+    const form = e.currentTarget
+    const honeypot = (form.elements.namedItem('bot-field') as HTMLInputElement | null)?.value ?? ''
+
+    const body = new URLSearchParams({
+      'form-name': FORM_NAME,
+      name: values.name.trim(),
+      email: values.email.trim(),
+      message: values.message.trim(),
+      'bot-field': honeypot,
+    })
+
+    try {
+      const res = await fetch('/', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+        body: body.toString(),
+      })
+      if (!res.ok) throw new Error(`Unexpected response: ${res.status}`)
+      setStatus('success')
+    } catch {
+      // Keep entered values so the user can retry.
+      setStatus('error')
+    }
+  }
+
+  const describedBy = (field: FieldName) => (errors[field] ? `${field}-error` : undefined)
+
+  return (
+    <section className="glass-bg mx-auto mt-12 max-w-xl translate-y-1 animate-[fadeInUp_0.4s_ease-out_forwards] rounded-xl border border-white/20 p-6 opacity-0 shadow-md backdrop-blur dark:border-white/10">
+      <h2 className="mb-6 text-center text-lg font-semibold text-gray-800 dark:text-gray-100">
+        {t('contact.form.heading')}
+      </h2>
+
+      {status === 'success' ? (
+        <div
+          role="status"
+          aria-live="polite"
+          className="rounded-lg border border-[var(--color-primary-300)] bg-[var(--color-primary-50)]/60 p-4 text-center text-sm text-[var(--color-primary-800)] dark:border-[var(--color-primary-700)] dark:bg-[var(--color-primary-900)]/40 dark:text-[var(--color-primary-100)]"
+        >
+          {t('contact.form.success')}
+        </div>
+      ) : (
+        <form
+          name={FORM_NAME}
+          method="POST"
+          data-netlify="true"
+          data-netlify-honeypot="bot-field"
+          noValidate
+          onSubmit={handleSubmit}
+          className="flex flex-col gap-4"
+        >
+          {/* Netlify hidden identifier */}
+          <input type="hidden" name="form-name" value={FORM_NAME} />
+
+          {/* Honeypot: hidden from sighted users and keyboard */}
+          <p className="hidden" aria-hidden="true">
+            <label>
+              Do not fill this out if you are human:
+              <input name="bot-field" tabIndex={-1} autoComplete="off" />
+            </label>
+          </p>
+
+          <div className="flex flex-col gap-1">
+            <label
+              htmlFor="contact-name"
+              className="text-sm font-medium text-gray-700 dark:text-gray-200"
+            >
+              {t('contact.form.name_label')}
+            </label>
+            <input
+              id="contact-name"
+              name="name"
+              type="text"
+              value={values.name}
+              onChange={handleChange('name')}
+              onBlur={handleBlur('name')}
+              placeholder={t('contact.form.name_placeholder')}
+              aria-invalid={errors.name ? true : undefined}
+              aria-describedby={describedBy('name')}
+              className={`${shared} ${errors.name ? invalidRing : ''}`}
+            />
+            {errors.name && (
+              <p id="name-error" className="text-xs text-red-600 dark:text-red-400">
+                {errors.name}
+              </p>
+            )}
+          </div>
+
+          <div className="flex flex-col gap-1">
+            <label
+              htmlFor="contact-email"
+              className="text-sm font-medium text-gray-700 dark:text-gray-200"
+            >
+              {t('contact.form.email_label')}
+            </label>
+            <input
+              id="contact-email"
+              name="email"
+              type="email"
+              value={values.email}
+              onChange={handleChange('email')}
+              onBlur={handleBlur('email')}
+              placeholder={t('contact.form.email_placeholder')}
+              aria-invalid={errors.email ? true : undefined}
+              aria-describedby={describedBy('email')}
+              className={`${shared} ${errors.email ? invalidRing : ''}`}
+            />
+            {errors.email && (
+              <p id="email-error" className="text-xs text-red-600 dark:text-red-400">
+                {errors.email}
+              </p>
+            )}
+          </div>
+
+          <div className="flex flex-col gap-1">
+            <label
+              htmlFor="contact-message"
+              className="text-sm font-medium text-gray-700 dark:text-gray-200"
+            >
+              {t('contact.form.message_label')}
+            </label>
+            <textarea
+              id="contact-message"
+              name="message"
+              rows={5}
+              value={values.message}
+              onChange={handleChange('message')}
+              onBlur={handleBlur('message')}
+              placeholder={t('contact.form.message_placeholder')}
+              aria-invalid={errors.message ? true : undefined}
+              aria-describedby={describedBy('message')}
+              className={`${shared} resize-y ${errors.message ? invalidRing : ''}`}
+            />
+            {errors.message && (
+              <p id="message-error" className="text-xs text-red-600 dark:text-red-400">
+                {errors.message}
+              </p>
+            )}
+          </div>
+
+          {status === 'error' && (
+            <div
+              role="status"
+              aria-live="polite"
+              className="rounded-lg border border-red-300 bg-red-50/70 p-3 text-sm text-red-700 dark:border-red-500/60 dark:bg-red-900/30 dark:text-red-300"
+            >
+              {t('contact.form.error')}
+            </div>
+          )}
+
+          <button
+            type="submit"
+            disabled={status === 'submitting'}
+            className="bg-primary-600 hover:bg-primary-700 focus-visible:outline-primary-500 mt-2 inline-flex items-center justify-center rounded-lg px-4 py-2 text-sm font-medium text-white shadow-sm transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-not-allowed disabled:opacity-60"
+          >
+            {status === 'submitting' ? t('contact.form.submitting') : t('contact.form.submit')}
+          </button>
+        </form>
+      )}
+    </section>
+  )
+}

--- a/locales/en.json
+++ b/locales/en.json
@@ -50,8 +50,28 @@
   "contact": {
     "title": "Get in touch",
     "intro": "I’m always open to thoughtful conversations around technology, systems, and ideas in progress.\n\nIf you’re working on complex challenges, exploring new directions, or simply want to exchange perspectives, feel free to reach out.",
-    "methods_intro": "The easiest way to contact me is by email.",
-    "linkedin_hint": "You can also reach me on "
+    "methods_intro": "Prefer not to use the form? You can also reach me directly by email.",
+    "linkedin_hint": "You can also reach me on ",
+    "form": {
+      "heading": "Send me a message",
+      "name_label": "Name",
+      "name_placeholder": "Your name",
+      "email_label": "Email",
+      "email_placeholder": "you@example.com",
+      "message_label": "Message",
+      "message_placeholder": "What would you like to talk about?",
+      "submit": "Send message",
+      "submitting": "Sending…",
+      "success": "Thanks for reaching out — your message has been sent. I’ll get back to you soon.",
+      "error": "Something went wrong while sending your message. Please try again.",
+      "errors": {
+        "name_required": "Please enter your name.",
+        "email_required": "Please enter your email address.",
+        "email_invalid": "Please enter a valid email address.",
+        "message_required": "Please enter a message.",
+        "message_too_short": "Your message should be at least 10 characters."
+      }
+    }
   },
   "hero": {
     "taglines": {

--- a/locales/it.json
+++ b/locales/it.json
@@ -69,8 +69,28 @@
   "contact": {
     "title": "Scrivimi",
     "intro": "Sono sempre disponibile a confrontarmi su tecnologia, sistemi e idee in evoluzione.\n\nSe stai lavorando su problemi complessi, esplorando nuove direzioni o semplicemente vuoi scambiare punti di vista, non esitare a contattarmi.",
-    "methods_intro": "Il modo più semplice per contattarmi è via email.",
-    "linkedin_hint": "Puoi anche trovarmi su "
+    "methods_intro": "Preferisci non usare il modulo? Puoi anche contattarmi direttamente via email.",
+    "linkedin_hint": "Puoi anche trovarmi su ",
+    "form": {
+      "heading": "Scrivimi un messaggio",
+      "name_label": "Nome",
+      "name_placeholder": "Il tuo nome",
+      "email_label": "Email",
+      "email_placeholder": "tu@esempio.com",
+      "message_label": "Messaggio",
+      "message_placeholder": "Di cosa vorresti parlare?",
+      "submit": "Invia messaggio",
+      "submitting": "Invio in corso…",
+      "success": "Grazie per avermi scritto — il tuo messaggio è stato inviato. Ti risponderò al più presto.",
+      "error": "Qualcosa è andato storto durante l’invio del messaggio. Riprova.",
+      "errors": {
+        "name_required": "Inserisci il tuo nome.",
+        "email_required": "Inserisci il tuo indirizzo email.",
+        "email_invalid": "Inserisci un indirizzo email valido.",
+        "message_required": "Inserisci un messaggio.",
+        "message_too_short": "Il messaggio deve contenere almeno 10 caratteri."
+      }
+    }
   },
   "home": {
     "projects": {

--- a/plans/contact-form-netlify.md
+++ b/plans/contact-form-netlify.md
@@ -1,0 +1,395 @@
+# Plan: Bilingual Netlify Contact Form
+
+| Field       | Value                          |
+| ----------- | ------------------------------ |
+| **Title**   | Bilingual Netlify Contact Form |
+| **Spec**    | specs/contact-form-netlify.md  |
+| **Type**    | feature                        |
+| **Branch**  | feat/contact-form-netlify      |
+| **Created** | 2026-08-04 00:00:00            |
+| **Status**  | IMPLEMENTED                    |
+
+## Context
+
+The `/contact` page currently exposes only passive email/LinkedIn methods
+(`components/contact/ContactMethods.tsx`) and offers no way to send a message
+in-page. This plan adds an accessible, bilingual (EN/IT) contact form as the
+primary CTA above the existing methods, backed by Netlify Forms. Because the
+site is a static export (`output: 'export'`) with client-rendered components,
+a static HTML detection form under `public/` is required so Netlify registers
+the form at deploy time, while the interactive React form submits via AJAX.
+
+## Branch Strategy
+
+> **Before implementation, create a new branch from the repo's base
+> branch.** The implementer auto-detects the base in this priority
+> order: `develop` → `main` → `master` → `origin/HEAD`. The branch
+> name is `feat/contact-form-netlify`.
+>
+> Reference command (the implementer adapts to the detected base):
+>
+> ```bash
+> git checkout <base> && git pull --ff-only && git checkout -b feat/contact-form-netlify
+> ```
+>
+> If the repo is not a git workspace, branch creation is skipped and
+> noted in the implementation report.
+
+## Commit Strategy
+
+All commits follow [Conventional Commits v1.0.0](https://www.conventionalcommits.org/en/v1.0.0/).
+
+Format: `<type>[(<scope>)]: <imperative description>`
+
+One commit per task. Each task in the Tasks section maps to exactly one commit.
+
+## Build & Test Commands
+
+| Action | Command                                       |
+| ------ | --------------------------------------------- |
+| Lint   | `npm run lint`                                |
+| Build  | `npm run build` (Next static export → `out/`) |
+| Dev    | `npm run dev`                                 |
+
+> **Note — no automated test framework.** The project has no Jest/Vitest/
+> Playwright setup and no existing `*.test.*` / `*.spec.*` files. Verification
+> is therefore manual (lint + build + local dev-server checks, and a Netlify
+> deploy/preview check for form registration). Tasks below specify manual test
+> steps rather than automated test files. Do **not** introduce a test framework
+> — that is out of scope for this spec.
+
+## Tasks
+
+### Task 1: Add bilingual `contact.form.*` locale strings `[S]`
+
+**Goal**: Add all user-facing form strings to both locale files under
+`contact.form.*` so every label, placeholder, validation error, and status
+message is available in EN and IT.
+
+**Files**:
+
+| File              | Action | Description                                                |
+| ----------------- | ------ | ---------------------------------------------------------- |
+| `locales/en.json` | modify | Add `form` object inside existing `contact` block          |
+| `locales/it.json` | modify | Add matching `form` object inside existing `contact` block |
+
+**Reuse**:
+
+| File                           | What to reuse                                |
+| ------------------------------ | -------------------------------------------- |
+| `locales/en.json` / `it.json`  | Existing `contact` block structure & tone    |
+| `contexts/LanguageContext.tsx` | `t()` dot-notation + `{{var}}` interpolation |
+
+**Steps**:
+
+1. In both files, inside the existing `contact` object (alongside `title`,
+   `intro`, `methods_intro`, `linkedin_hint`), add a `form` object with the
+   keys below. Keep IT translations natural, matching the existing informal tone.
+2. Suggested keys (finalise exact wording during implementation):
+   - `heading`, `name_label`, `name_placeholder`, `email_label`,
+     `email_placeholder`, `message_label`, `message_placeholder`
+   - `submit`, `submitting`
+   - `success`, `error`
+   - `errors.name_required`, `errors.email_required`, `errors.email_invalid`,
+     `errors.message_required`, `errors.message_too_short`
+3. Ensure both files have identical key sets (only values differ) to avoid
+   `t()` falling back to raw keys in one language.
+
+**Tests** (manual):
+
+- After Task 3, toggle EN/IT via the language switcher and confirm every string
+  renders translated (no raw dot-notation keys appear).
+
+**Acceptance criteria covered**: "All new user-facing strings exist in both
+`locales/en.json` and `locales/it.json` under `contact.form.*`, and render in
+both languages."
+
+**Commit**: `feat(i18n): add bilingual contact form strings`
+
+---
+
+### Task 2: Add static Netlify form-detection HTML in `public/` `[S]`
+
+**Goal**: Provide a plain static HTML form that Netlify's build-time parser can
+detect, so the form is registered at deploy time despite the React form being
+client-rendered.
+
+**Files**:
+
+| File                  | Action | Description                                      |
+| --------------------- | ------ | ------------------------------------------------ |
+| `public/__forms.html` | create | Minimal static HTML page with the detection form |
+
+**Reuse**:
+
+| File                    | What to reuse                                                  |
+| ----------------------- | -------------------------------------------------------------- |
+| `next.config.js`        | `output: 'export'` copies `public/*` into `out/` automatically |
+| `scripts/postbuild.mjs` | postbuild only runs RSS; it will not remove `public/` files    |
+
+**Steps**:
+
+1. Create `public/__forms.html` — a bare `<html>` document containing a single
+   `<form name="contact" data-netlify="true" netlify-honeypot="bot-field" hidden>`.
+2. Include exactly the fields the React form posts, with matching `name`
+   attributes: `form-name` (hidden, value `contact`), `name`, `email`,
+   `message`, and the honeypot `bot-field`.
+3. Confirm the form `name` (`contact`) is the single source of truth reused by
+   the React form in Task 3 and the AJAX body in Task 4.
+
+**Tests** (manual):
+
+- Run `npm run build` and confirm `out/__forms.html` exists and contains the
+  form markup (static export copies `public/`).
+- On a Netlify deploy/preview, confirm a `contact` form appears under
+  Site → Forms (deploy-time verification; note in the report if not deployable
+  during implementation).
+
+**Acceptance criteria covered**: "A static HTML detection form exists under
+`public/` with matching field names and `data-netlify="true"`, and ends up in
+the deployed `out/` directory."
+
+**Commit**: `feat(contact): add static netlify form-detection html`
+
+---
+
+### Task 3: Build `ContactForm` markup, fields, and glass styling `[M]`
+
+**Goal**: Create the client component with the form structure — Name, Email,
+Message, hidden honeypot, hidden `form-name` — styled to match the
+glassmorphism design and `@tailwindcss/forms`, with full accessibility markup.
+No submission/validation logic yet (added in Task 4).
+
+**Files**:
+
+| File                                 | Action | Description                            |
+| ------------------------------------ | ------ | -------------------------------------- |
+| `components/contact/ContactForm.tsx` | create | Client component rendering the form UI |
+
+**Reuse**:
+
+| File                                         | What to reuse                                                                                                                                |
+| -------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
+| `components/contact/ContactMethods.tsx`      | `'use client'` + `useLanguage()`/`t()` pattern; glass card classes (`glass-bg`, `backdrop-blur`, rounded border, shadow, fadeInUp animation) |
+| `contexts/LanguageContext.tsx`               | `useLanguage()` hook for `t()`                                                                                                               |
+| `css/tailwind.css`                           | `glass-bg` utility, OKLCH `--color-primary-*` tokens, existing focus-outline styles                                                          |
+| `@tailwindcss/forms` (in `css/tailwind.css`) | Base form-control styling                                                                                                                    |
+
+**Steps**:
+
+1. Create `components/contact/ContactForm.tsx` as a `'use client'` component
+   using `useLanguage()` for `t()`.
+2. Render a glass card matching `ContactMethods.tsx` styling, containing a
+   `<form name="contact">` with:
+   - Hidden `form-name` input (value `contact`).
+   - Honeypot: a visually-hidden, non-focusable wrapper containing
+     `<input name="bot-field" tabIndex={-1} autoComplete="off">` with
+     `aria-hidden="true"` (hidden from sighted users and keyboard).
+   - Name (`text`), Email (`type="email"`), Message (`textarea`), each with an
+     associated `<label htmlFor>` and localized label/placeholder from Task 1.
+3. Add accessibility scaffolding: stable `id`s for each field, `aria-invalid`
+   and `aria-describedby` wiring to per-field error `<p>` elements (rendered
+   conditionally, empty for now), and a submit `<button type="submit">` with
+   localized label.
+4. Reserve a status region: a `<div role="status" aria-live="polite">` for the
+   success/error banner (empty for now; populated in Task 4).
+5. Ensure visible focus states (rely on existing global focus-outline in
+   `css/tailwind.css`; add Tailwind focus classes where needed).
+
+**Tests** (manual):
+
+- Temporarily render the component (or wait for Task 5) and verify in dev
+  (`npm run dev`) that fields, labels, and glass styling display correctly in
+  light/dark and that the honeypot is not reachable via Tab.
+- Run `npm run lint`.
+
+**Acceptance criteria covered**: component renders form with Name/Email/Message
+
+- hidden honeypot + hidden `form-name`; labels present; `aria-invalid`/
+  `aria-describedby` wiring; live region; glassmorphism + `@tailwindcss/forms`;
+  honeypot hidden and not focusable.
+
+**Commit**: `feat(contact): add contact form component markup and styling`
+
+---
+
+### Task 4: Add validation, AJAX submission, and success/error states `[M]`
+
+**Goal**: Wire up client-side validation, the Netlify AJAX POST, in-flight
+disabled state, and inline bilingual success/error handling in `ContactForm`.
+
+**Files**:
+
+| File                                 | Action | Description                                      |
+| ------------------------------------ | ------ | ------------------------------------------------ |
+| `components/contact/ContactForm.tsx` | modify | Add state, validation, submit handler, status UI |
+
+**Reuse**:
+
+| File                           | What to reuse                                 |
+| ------------------------------ | --------------------------------------------- |
+| `contexts/LanguageContext.tsx` | `t()` for reactive validation/status messages |
+| Task 1 locale keys             | `errors.*`, `success`, `error`, `submitting`  |
+
+**Steps**:
+
+1. Add React state for field values, per-field errors, submission status
+   (`idle | submitting | success | error`).
+2. Validation (on submit and on blur), all trimmed:
+   - Name: required (non-empty after trim).
+   - Email: required + basic format check (simple regex, e.g. `/^\S+@\S+\.\S+$/`).
+   - Message: required + minimum length 10.
+   - Set `aria-invalid` and populate `aria-describedby` error text via `t()`.
+3. On valid submit, build an `application/x-www-form-urlencoded` body with
+   `URLSearchParams` including `form-name=contact`, the three fields, and
+   `bot-field`; `fetch('/', { method: 'POST', headers, body })`.
+4. While in flight: set status `submitting`, disable the submit button (show
+   `submitting` label), prevent duplicate submits.
+5. On 2xx: set status `success`, replace the form body with the localized
+   thank-you message in the live region (no navigation).
+6. On network error or non-2xx: set status `error`, show the localized error
+   banner, keep entered values for retry, re-enable submit.
+7. Ensure all messages read from `t()` so they update reactively on EN/IT toggle.
+
+**Tests** (manual):
+
+- In `npm run dev`: submit empty/whitespace fields → per-field errors appear;
+  invalid email → email error; short message → min-length error.
+- Simulate success/failure (e.g. via network throttling/offline in devtools) →
+  confirm inline success and error states, disabled button while pending, and
+  that values persist on error.
+- Toggle EN/IT while errors/status are visible → messages re-render translated.
+
+**Acceptance criteria covered**: valid submit AJAX POST + inline success;
+failed submit inline error + preserved values; validation rules
+(required/format/min-length) with inline per-field errors; double-submit
+prevention; language-switch reactivity.
+
+**Commit**: `feat(contact): add validation and netlify ajax submission`
+
+---
+
+### Task 5: Render `ContactForm` on the contact page `[S]`
+
+**Goal**: Place `ContactForm` above the existing `ContactMethods` on
+`/contact`, keeping `ContactIntro` and `ContactMethods` unchanged.
+
+**Files**:
+
+| File                   | Action | Description                                            |
+| ---------------------- | ------ | ------------------------------------------------------ |
+| `app/contact/page.tsx` | modify | Import and render `ContactForm` above `ContactMethods` |
+
+**Reuse**:
+
+| File                   | What to reuse                                                     |
+| ---------------------- | ----------------------------------------------------------------- |
+| `app/contact/page.tsx` | Existing `SectionContainer` + section layout; `allAuthors` lookup |
+
+**Steps**:
+
+1. Import `ContactForm` from `@/components/contact/ContactForm`.
+2. Render it inside the existing `<section>` between `ContactIntro` and
+   `ContactMethods`, so the form is the primary CTA and email/LinkedIn remain
+   below.
+3. Leave `ContactIntro` and `ContactMethods` (and the `author` email/linkedin
+   props) untouched.
+
+**Tests** (manual):
+
+- `npm run dev`: confirm order is Intro → Form → Methods, and the existing
+  email/LinkedIn card still renders beneath the form.
+- `npm run build` succeeds (static export).
+
+**Acceptance criteria covered**: "`app/contact/page.tsx` renders `ContactForm`
+above the existing `ContactMethods`; the email and LinkedIn methods still
+display beneath the form."
+
+**Commit**: `feat(contact): render contact form on contact page`
+
+---
+
+### Task 6: Verify CSP permits the same-origin Netlify POST `[S]`
+
+**Goal**: Confirm the AJAX POST is not blocked by the site's CSP; add a
+`form-action 'self'` directive only if verification shows it is needed.
+
+**Files**:
+
+| File             | Action             | Description                                         |
+| ---------------- | ------------------ | --------------------------------------------------- |
+| `next.config.js` | modify (if needed) | Add `form-action 'self'` to `ContentSecurityPolicy` |
+
+**Reuse**:
+
+| File             | What to reuse                                                               |
+| ---------------- | --------------------------------------------------------------------------- |
+| `next.config.js` | Existing `ContentSecurityPolicy` template (`connect-src *` already present) |
+
+**Steps**:
+
+1. Review the current CSP: `connect-src *` already permits the same-origin
+   `fetch` POST; there is no `form-action` directive (so it falls back to
+   `default-src 'self'`, which allows same-origin form submission).
+2. In `npm run dev`/preview, submit the form and check the browser console for
+   any CSP violation on the POST.
+3. If — and only if — a CSP violation is observed, add `form-action 'self';`
+   to the `ContentSecurityPolicy` string in `next.config.js`. Otherwise leave
+   CSP unchanged and note that verification passed.
+4. Note: `next.config.js` `headers()` do not apply to static-export output on
+   Netlify (headers come from Netlify), so this is primarily a dev-time
+   verification; document the finding in the implementation report.
+
+**Tests** (manual):
+
+- Submit the form in the browser; confirm no CSP error in console and the POST
+  reaches the network.
+
+**Acceptance criteria covered**: "The CSP in `next.config.js` is verified to
+permit the same-origin AJAX POST; if a `form-action` directive is introduced,
+it allows `'self'`."
+
+**Commit**: `chore(security): verify csp allows contact form post`
+
+> If no change to `next.config.js` is required, fold this verification note into
+> Task 4's commit instead of creating an empty commit.
+
+---
+
+**Task ordering**: Task 1 (locale strings) and Task 2 (static HTML) are
+independent and can be done first in any order. Task 3 depends on Task 1
+(uses `t()` keys). Task 4 depends on Task 3. Task 5 depends on Task 3
+(component must exist). Task 6 depends on Task 4/5 (needs a working submit to
+verify). Recommended order: 1 → 2 → 3 → 4 → 5 → 6.
+
+## Edge Cases & Error Handling
+
+- **JavaScript disabled**: React AJAX will not run; the email/LinkedIn methods
+  below remain a working fallback. The static `public/__forms.html` handles
+  Netlify detection only. (Tasks 2, 5)
+- **Honeypot filled (bot)**: Netlify handles as spam; UI shows normal success,
+  no trap signalling. (Tasks 3, 4)
+- **Network failure / offline / non-2xx**: Inline error state, values
+  preserved, retry allowed. (Task 4)
+- **Double submit**: Submit disabled while `submitting`. (Task 4)
+- **Language switched mid-session**: All strings via `t()` re-render. (Tasks 1, 4)
+- **Empty/whitespace-only fields**: Trimmed and treated invalid. (Task 4)
+- **Netlify form not detected**: Mitigated by static detection form; verified at
+  deploy time. (Task 2)
+
+## Verification
+
+1. `npm run lint` passes.
+2. `npm run build` succeeds and `out/__forms.html` contains the detection form.
+3. `npm run dev`: on `/contact`, confirm order Intro → Form → Methods;
+   glassmorphism styling in light/dark; honeypot not Tab-reachable.
+4. Validation: empty/whitespace, invalid email, and too-short message each show
+   the correct inline per-field error; submit is blocked while invalid.
+5. Submission: successful POST shows inline bilingual thank-you (no navigation);
+   simulated failure shows inline bilingual error with values preserved and
+   button disabled while pending.
+6. Toggle EN/IT with errors/status visible → messages re-render translated; no
+   raw dot-notation keys appear in either language.
+7. No CSP violation on the POST in the browser console.
+8. (Deploy-time) On a Netlify preview, a `contact` form appears under
+   Site → Forms and a test submission is captured.

--- a/public/__forms.html
+++ b/public/__forms.html
@@ -1,0 +1,24 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Netlify Form Detection</title>
+  </head>
+  <body>
+    <!--
+      Static form used solely for Netlify's build-time form detection.
+      The site is a Next.js static export with a client-rendered React form
+      (components/contact/ContactForm.tsx), which Netlify cannot parse at
+      deploy time. This static HTML form registers the "contact" form so the
+      React form's AJAX POST is accepted. Field names must match the React
+      form and the AJAX body exactly.
+    -->
+    <form name="contact" data-netlify="true" netlify-honeypot="bot-field" hidden>
+      <input type="hidden" name="form-name" value="contact" />
+      <input type="text" name="name" />
+      <input type="email" name="email" />
+      <textarea name="message"></textarea>
+      <input name="bot-field" />
+    </form>
+  </body>
+</html>

--- a/specs/contact-form-netlify.md
+++ b/specs/contact-form-netlify.md
@@ -1,0 +1,184 @@
+# Bilingual Netlify Contact Form
+
+| Field       | Value                                                |
+| ----------- | ---------------------------------------------------- |
+| **Title**   | Bilingual Netlify Contact Form                       |
+| **Type**    | feature                                              |
+| **Scope**   | Contact page (`app/contact/`, `components/contact/`) |
+| **Created** | 2026-08-04 00:00:00                                  |
+| **Status**  | IMPLEMENTED                                          |
+
+## Problem Statement
+
+The `/contact` page currently offers only passive contact channels — an email
+address and a LinkedIn link (rendered by `components/contact/ContactMethods.tsx`).
+Visitors who want to reach out must leave the site to open their mail client or
+LinkedIn. There is no way to send a message directly from the page, which adds
+friction and loses visitors who would otherwise message in the moment.
+
+The site is a fully static export (`next.config.js` sets `output: 'export'`) with
+no server runtime, deployed on Netlify. This constrains any form solution to a
+static-friendly backend — Netlify Forms — combined with client-side interactivity.
+
+## Desired Outcome
+
+The `/contact` page presents an accessible, bilingual (EN/IT) contact form as the
+primary call to action, styled to match the site's glassmorphism design language.
+The form submits to Netlify Forms via a client-side AJAX POST, shows inline
+validation, and displays inline success/error states without leaving the page. The
+existing email and LinkedIn methods remain on the page beneath the form as a
+secondary option.
+
+Layout and structure:
+
+- A new client component `components/contact/ContactForm.tsx` renders the
+  interactive form.
+- `app/contact/page.tsx` renders `ContactForm` **above** the existing
+  `ContactMethods` card. `ContactIntro` and `ContactMethods` remain unchanged in
+  behaviour; the form is the primary CTA and the methods card is retained as a
+  secondary channel below it.
+- The form is visually consistent with the existing glass card
+  (`glass-bg`, `backdrop-blur`, rounded border, OKLCH teal/amber theming) and uses
+  the already-installed `@tailwindcss/forms` styling.
+
+Fields:
+
+- **Name** — text, required.
+- **Email** — email, required, basic format validation.
+- **Message** — textarea, required, minimum length (10 characters).
+- **Honeypot** — hidden field (e.g. `bot-field`) for spam protection; must not be
+  perceivable or focusable by real users.
+- A hidden `form-name` field matching the Netlify form name.
+
+Netlify integration (static export + client components):
+
+- Because Netlify's build-time form detection parses the static HTML produced at
+  deploy time — not client-rendered React DOM — a **plain static HTML form** with
+  all the same fields and the same `name`/`form-name` is added under `public/`
+  (e.g. `public/__forms.html` or an equivalent static HTML file that ends up in the
+  `out/` publish directory). This static form carries the `data-netlify="true"` and
+  honeypot attributes and exists solely so Netlify registers the form at deploy time.
+- The React `ContactForm` submits via `fetch` (AJAX) using an
+  `application/x-www-form-urlencoded` body whose `form-name` matches the registered
+  form. The React form also carries `data-netlify`-style attributes for consistency,
+  but detection relies on the static HTML form.
+
+Submission & states:
+
+- On submit, the form validates client-side; invalid fields show inline,
+  per-field error messages and prevent submission.
+- On valid submit, an AJAX POST is sent to the site origin. While in flight, the
+  submit control shows a pending/disabled state.
+- On success (2xx), the form is replaced/overlaid with a bilingual thank-you
+  message; the page does not navigate.
+- On failure (network error or non-2xx), a bilingual error message is shown and the
+  user can retry without losing entered data.
+
+Internationalisation:
+
+- All user-facing strings (labels, placeholders, validation messages, submit label,
+  pending label, success message, error message) are added to **both**
+  `locales/en.json` and `locales/it.json`, nested under `contact.form.*`
+  (e.g. `contact.form.name_label`, `contact.form.errors.email_invalid`,
+  `contact.form.success`, `contact.form.error`). Strings are consumed via the
+  existing `t()` from `contexts/LanguageContext.tsx`.
+
+Accessibility:
+
+- Every input has an associated `<label>`.
+- Invalid fields use `aria-invalid` and link to their error via
+  `aria-describedby`.
+- Success and error banners use an appropriate live region
+  (`role="status"` / `aria-live`).
+- Visible focus states on all interactive elements; the form is fully operable by
+  keyboard.
+
+## Acceptance Criteria
+
+- [ ] A new client component `components/contact/ContactForm.tsx` renders a form with
+      Name, Email, and Message fields plus a hidden honeypot and hidden `form-name`.
+- [ ] `app/contact/page.tsx` renders `ContactForm` above the existing
+      `ContactMethods`; the email and LinkedIn methods still display beneath the form.
+- [ ] A static HTML detection form exists under `public/` with matching field names
+      and `data-netlify="true"`, and ends up in the deployed `out/` directory so
+      Netlify registers the form at deploy time.
+- [ ] Submitting a valid form performs an AJAX POST and, on success, shows an inline
+      bilingual thank-you message without page navigation.
+- [ ] A failed submission shows an inline bilingual error message and preserves the
+      user's entered values for retry.
+- [ ] Client-side validation enforces: Name required, Email required + valid format,
+      Message required + minimum length; invalid fields show inline per-field errors.
+- [ ] The honeypot field is present, hidden from sighted users, and not focusable via
+      keyboard.
+- [ ] All new user-facing strings exist in both `locales/en.json` and
+      `locales/it.json` under `contact.form.*`, and render in both languages.
+- [ ] The form matches the site's glassmorphism styling and uses `@tailwindcss/forms`.
+- [ ] Inputs have labels; invalid fields expose `aria-invalid` + `aria-describedby`;
+      success/error messages use a live region; focus states are visible and the form
+      is keyboard-operable.
+- [ ] The CSP in `next.config.js` is verified to permit the same-origin AJAX POST;
+      if a `form-action` directive is introduced, it allows `'self'`.
+
+## Edge Cases & Error Handling
+
+- **JavaScript disabled**: AJAX submit will not run. The static/native form markup
+  should degrade to a standard Netlify POST where feasible; at minimum the email and
+  LinkedIn methods below remain available as a fallback channel.
+- **Honeypot filled (bot)**: Submission is treated as spam by Netlify; the user-facing
+  UI need not distinguish it from a normal success (avoid signalling the trap).
+- **Network failure / offline**: Show the bilingual error state; do not clear the
+  form; allow retry.
+- **Non-2xx response from Netlify**: Treated the same as a failure — show error state.
+- **Double submit**: Submit control is disabled while a request is in flight to prevent
+  duplicate POSTs.
+- **Language switched mid-session**: All labels, errors, and status messages update
+  reactively via `t()` when the user toggles EN/IT.
+- **Empty / whitespace-only fields**: Treated as invalid (trimmed before validation).
+- **Netlify form not detected**: Documented as a known risk of static export; the
+  static HTML detection form under `public/` is the mitigation.
+
+## Dependencies & Constraints
+
+- **Static export only** — `output: 'export'` in `next.config.js`; no server runtime,
+  API routes, or server actions are available.
+- **Netlify Forms** is the backend; form registration depends on Netlify's build-time
+  HTML parsing, hence the static detection form.
+- **Netlify redirects** — `netlify.toml` has a catch-all `/* -> /index.html` (200)
+  SPA-style redirect; the plan must confirm this does not interfere with Netlify's
+  form POST handling and that the static detection HTML is reachable/registered.
+- **CSP** — `next.config.js` currently sets `connect-src *` (which should permit the
+  same-origin fetch) and defines no `form-action` directive; verify the POST is
+  allowed and, if adding `form-action`, include `'self'`.
+- **i18n** — must use the existing custom client-side context
+  (`contexts/LanguageContext.tsx`, `t()` dot-notation) backed by `locales/en.json`
+  and `locales/it.json`; do not introduce Next.js built-in i18n or locale-prefixed
+  URLs.
+- **Styling** — glassmorphism utilities (`glass-bg`, `backdrop-blur`) and OKLCH
+  teal/amber theming from `css/tailwind.css`; `@tailwindcss/forms` (already installed)
+  for form control styling.
+- Existing `ContactIntro.tsx` and `ContactMethods.tsx` behaviour is preserved.
+
+## Out of Scope
+
+- reCAPTCHA or any spam protection beyond the honeypot field.
+- A dedicated `/contact/success` route or post-submit redirect (success is inline).
+- Email autoresponders, notification routing, or Netlify Forms notification
+  configuration in the Netlify dashboard.
+- Storing/exporting submissions beyond what Netlify Forms provides by default.
+- Adding new languages beyond the existing EN/IT.
+- Changes to the email/LinkedIn methods themselves beyond their placement below the
+  form.
+
+## Notes
+
+- Investigation confirmed: static export means Netlify cannot see the client-rendered
+  React form at build time, so a static HTML detection form under `public/` is the
+  chosen, reliable mechanism (per dialogue).
+- Suggested locale key grouping under `contact.form.*`:
+  labels (`name_label`, `email_label`, `message_label`), placeholders, `submit`,
+  `submitting`, `success`, `error`, and `errors.*`
+  (e.g. `errors.name_required`, `errors.email_required`, `errors.email_invalid`,
+  `errors.message_required`, `errors.message_too_short`). Exact keys to be finalised
+  during planning/implementation.
+- The existing `contact` block in the locale files already holds `title`, `intro`,
+  `methods_intro`, `linkedin_hint`; the new `contact.form.*` keys sit alongside them.


### PR DESCRIPTION
Add an accessible EN/IT contact form to /contact backed by Netlify Forms. Includes a static form-detection HTML file for static-export compatibility, client-side validation, honeypot spam protection, and inline success/error states. Email/LinkedIn methods retained below the form as an alternative.