### PR TITLE
feat(search): expand kbar index to all content with language-aware results

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -4,7 +4,6 @@ import 'remark-github-blockquote-alert/alert.css'
 
 import { IBM_Plex_Sans, IBM_Plex_Mono } from 'next/font/google'
 import { Analytics, AnalyticsConfig } from 'pliny/analytics'
-import { SearchProvider, SearchConfig } from 'pliny/search'
 import Layout from '@/components/common/Layout'
 import siteMetadata from '@/data/siteMetadata'
 import { Metadata } from 'next'
@@ -112,9 +111,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
           Skip to main content
         </a>
         <Analytics analyticsConfig={siteMetadata.analytics as AnalyticsConfig} />
-        <SearchProvider searchConfig={siteMetadata.search as SearchConfig}>
-          <Layout>{children}</Layout>
-        </SearchProvider>
+        <Layout>{children}</Layout>
       </body>
     </html>
   )

--- a/components/common/Layout.tsx
+++ b/components/common/Layout.tsx
@@ -6,20 +6,23 @@ import Footer from '@/components/common/Footer'
 import SectionContainer from '@/components/SectionContainer'
 import { ThemeProviders } from '@/app/theme-providers'
 import { LanguageProvider } from '@/contexts/LanguageContext'
+import SearchProvider from '@/components/search/SearchProvider'
 
 export default function Layout({ children }: { children: ReactNode }) {
   return (
     <ThemeProviders>
       <LanguageProvider>
-        <div className="flex min-h-screen flex-col bg-[var(--color-bg-light)] text-[var(--color-text-light)] transition-colors duration-300 dark:bg-[var(--color-bg-dark)] dark:text-[var(--color-text-dark)]">
-          <Header />
-          <SectionContainer>
-            <main id="main-content" className="flex-1 pt-16">
-              {children}
-            </main>
-          </SectionContainer>
-          <Footer />
-        </div>
+        <SearchProvider>
+          <div className="flex min-h-screen flex-col bg-[var(--color-bg-light)] text-[var(--color-text-light)] transition-colors duration-300 dark:bg-[var(--color-bg-dark)] dark:text-[var(--color-text-dark)]">
+            <Header />
+            <SectionContainer>
+              <main id="main-content" className="flex-1 pt-16">
+                {children}
+              </main>
+            </SectionContainer>
+            <Footer />
+          </div>
+        </SearchProvider>
       </LanguageProvider>
     </ThemeProviders>
   )

--- a/components/search/SearchProvider.tsx
+++ b/components/search/SearchProvider.tsx
@@ -1,0 +1,62 @@
+'use client'
+
+import { KBarSearchProvider } from 'pliny/search/KBar'
+import { useRouter } from 'next/navigation'
+import siteMetadata from '@/data/siteMetadata'
+import { useLanguage } from '@/contexts/LanguageContext'
+
+type SearchEntry = {
+  id: string
+  title: string
+  summary: string
+  type: string
+  url: string
+  lang: 'en' | 'it'
+}
+
+const searchDocumentsPath =
+  siteMetadata.search?.provider === 'kbar'
+    ? siteMetadata.search.kbarConfig.searchDocumentsPath
+    : false
+
+/**
+ * Custom kbar search provider that renders the expanded search index
+ * (blog posts, projects, the about page, and static pages). Each index
+ * entry is already localized and carries an absolute `url`, so unlike the
+ * default Pliny mapper we push `entry.url` directly and read the `type`
+ * field as the palette section.
+ *
+ * Results are scoped to the active UI language: only entries whose `lang`
+ * matches the current language are mapped into kbar actions. The provider
+ * is keyed on `lang` so toggling the language remounts it and rebuilds the
+ * action set (the index is tiny, so the remount cost is negligible).
+ */
+const SearchProvider = ({ children }: { children: React.ReactNode }) => {
+  const router = useRouter()
+  const { lang } = useLanguage()
+
+  return (
+    <KBarSearchProvider
+      key={lang}
+      kbarConfig={{
+        searchDocumentsPath,
+        onSearchDocumentsLoad(json: SearchEntry[]) {
+          return json
+            .filter((entry) => entry.lang === lang)
+            .map((entry) => ({
+              id: entry.id,
+              name: entry.title,
+              keywords: entry.summary || '',
+              section: entry.type,
+              subtitle: entry.summary,
+              perform: () => router.push(entry.url),
+            }))
+        },
+      }}
+    >
+      {children}
+    </KBarSearchProvider>
+  )
+}
+
+export default SearchProvider

--- a/contentlayer.config.ts
+++ b/contentlayer.config.ts
@@ -1,5 +1,4 @@
 import { defineDocumentType, ComputedFields, makeSource } from 'contentlayer2/source-files'
-import { writeFileSync } from 'fs'
 import readingTime from 'reading-time'
 import path from 'path'
 import { fromHtmlIsomorphic } from 'hast-util-from-html-isomorphic'
@@ -24,8 +23,8 @@ import rehypeCitation from 'rehype-citation'
 import rehypePrismPlus from 'rehype-prism-plus'
 import rehypePresetMinify from 'rehype-preset-minify'
 import siteMetadata from './data/siteMetadata'
-import { allCoreContent, sortPosts } from 'pliny/utils/contentlayer.js'
 import { createBlogTagCount } from '@/lib/generateBlogTagData'
+import { createSearchIndex } from './lib/generateSearchIndex'
 
 const root = process.cwd()
 
@@ -61,19 +60,6 @@ const baseComputedFields: ComputedFields = {
 const blogComputedFields: ComputedFields = {
   ...baseComputedFields,
   toc: { type: 'json', resolve: (doc) => extractTocHeadings(doc.body.raw) },
-}
-
-function createSearchIndex(allBlogs) {
-  if (
-    siteMetadata?.search?.provider === 'kbar' &&
-    siteMetadata.search.kbarConfig.searchDocumentsPath
-  ) {
-    writeFileSync(
-      `public/${path.basename(siteMetadata.search.kbarConfig.searchDocumentsPath)}`,
-      JSON.stringify(allCoreContent(sortPosts(allBlogs)))
-    )
-    console.log('Local search index generated...')
-  }
 }
 
 export const Blog = defineDocumentType(() => ({
@@ -314,9 +300,9 @@ export default makeSource({
     ],
   },
   onSuccess: async (importData) => {
-    const { allBlogs, allProjects } = await importData()
+    const { allBlogs, allProjects, allAuthors } = await importData()
     await createBlogTagCount(allBlogs)
     await createProjectTagCount(allProjects)
-    createSearchIndex(allBlogs)
+    await createSearchIndex(allBlogs, allProjects, allAuthors)
   },
 })

--- a/lib/generateSearchIndex.ts
+++ b/lib/generateSearchIndex.ts
@@ -1,0 +1,125 @@
+import { writeFileSync } from 'fs'
+import path from 'path'
+import siteMetadata from '../data/siteMetadata'
+import { staticSearchPages } from './searchStaticPages'
+
+type Locale = 'en' | 'it'
+
+type Localized = { en?: string; it?: string } | undefined
+
+export type SearchEntry = {
+  id: string
+  title: string
+  summary: string
+  type: 'Blog' | 'Project' | 'Page'
+  url: string
+  lang: Locale
+}
+
+const LOCALES: Locale[] = ['en', 'it']
+
+/**
+ * Resolve a localized `{ en, it }` field for a given locale, falling back
+ * to the other language when the requested one is missing so entries never
+ * carry an empty title/summary.
+ */
+function localize(field: Localized, locale: Locale): string {
+  if (!field) return ''
+  const other: Locale = locale === 'en' ? 'it' : 'en'
+  return field[locale] ?? field[other] ?? ''
+}
+
+/**
+ * Push one entry per locale (en + it) for a single piece of content. Both
+ * entries share the same URL because there are no language-specific routes.
+ */
+function emitLocalized(
+  entries: SearchEntry[],
+  {
+    title,
+    summary,
+    url,
+    type,
+  }: { title: Localized; summary: Localized; url: string; type: SearchEntry['type'] }
+) {
+  for (const locale of LOCALES) {
+    entries.push({
+      id: `${url}#${locale}`,
+      title: localize(title, locale),
+      summary: localize(summary, locale),
+      type,
+      url,
+      lang: locale,
+    })
+  }
+}
+
+/**
+ * Build the expanded, per-language, multi-type search index and write it to
+ * `public/<searchDocumentsPath>`. Covers blog posts, projects, the about
+ * page, and hand-authored static pages. Drafts are excluded.
+ */
+export async function createSearchIndex(allBlogs, allProjects, authors) {
+  if (
+    siteMetadata?.search?.provider !== 'kbar' ||
+    !siteMetadata.search.kbarConfig.searchDocumentsPath
+  ) {
+    return
+  }
+
+  const entries: SearchEntry[] = []
+
+  // Blog posts -> /<path> (path is `blog/<slug>`), skip drafts.
+  for (const post of allBlogs) {
+    if (post.draft === true) continue
+    emitLocalized(entries, {
+      title: post.title,
+      summary: post.summary,
+      url: `/${post.path}`,
+      type: 'Blog',
+    })
+  }
+
+  // Projects -> /projects/<slug>, skip drafts.
+  for (const project of allProjects) {
+    if (project.draft === true) continue
+    emitLocalized(entries, {
+      title: project.title,
+      summary: project.summary,
+      url: `/projects/${project.slug}`,
+      type: 'Project',
+    })
+  }
+
+  // About page -> /about (author has no localized title; use name + a
+  // localized description derived from occupation/company).
+  const author = authors?.find((a) => a.slug === 'default') ?? authors?.[0]
+  if (author) {
+    const role = [author.occupation, author.company].filter(Boolean).join(' · ')
+    emitLocalized(entries, {
+      title: { en: author.name, it: author.name },
+      summary: {
+        en: role ? `About ${author.name} — ${role}` : `About ${author.name}`,
+        it: role ? `Chi è ${author.name} — ${role}` : `Chi è ${author.name}`,
+      },
+      url: '/about',
+      type: 'Page',
+    })
+  }
+
+  // Hand-authored static pages.
+  for (const page of staticSearchPages) {
+    emitLocalized(entries, {
+      title: page.title,
+      summary: page.summary,
+      url: page.url,
+      type: page.type,
+    })
+  }
+
+  writeFileSync(
+    `public/${path.basename(siteMetadata.search.kbarConfig.searchDocumentsPath)}`,
+    JSON.stringify(entries)
+  )
+  console.log('Local search index generated...')
+}

--- a/lib/searchStaticPages.ts
+++ b/lib/searchStaticPages.ts
@@ -1,0 +1,43 @@
+export type Localized = { en: string; it: string }
+
+export type StaticSearchPage = {
+  url: string
+  type: 'Page'
+  title: Localized
+  summary: Localized
+}
+
+/**
+ * Hand-authored search entries for static routes that have no MDX source.
+ * Plain data only (no contentlayer imports) so it can be imported safely
+ * at build time by the search index generator.
+ */
+export const staticSearchPages: StaticSearchPage[] = [
+  {
+    url: '/contact',
+    type: 'Page',
+    title: { en: 'Contact', it: 'Contatti' },
+    summary: {
+      en: 'Get in touch to discuss technology, systems, and innovative ideas.',
+      it: 'Mettiti in contatto per parlare di tecnologia, sistemi e idee innovative.',
+    },
+  },
+  {
+    url: '/projects',
+    type: 'Page',
+    title: { en: 'Projects', it: 'Progetti' },
+    summary: {
+      en: 'Portfolio of projects across AR/XR, AI, computer vision, and experimental interfaces.',
+      it: 'Portfolio di progetti su AR/XR, AI, computer vision e interfacce sperimentali.',
+    },
+  },
+  {
+    url: '/blog',
+    type: 'Page',
+    title: { en: 'Blog', it: 'Blog' },
+    summary: {
+      en: 'Articles and notes on code, experiments, and the ideas behind the projects.',
+      it: 'Articoli e note su codice, esperimenti e le idee dietro i progetti.',
+    },
+  },
+]

--- a/plans/expand-search-index-all-content.md
+++ b/plans/expand-search-index-all-content.md
@@ -1,0 +1,307 @@
+# Plan: Expand Site Search Index to Cover All Content
+
+| Field       | Value                                         |
+| ----------- | --------------------------------------------- |
+| **Title**   | Expand Site Search Index to Cover All Content |
+| **Spec**    | specs/expand-search-index-all-content.md      |
+| **Type**    | feature                                       |
+| **Branch**  | feat/expand-search-index-all-content          |
+| **Created** | 2026-08-05 01:30:00                           |
+| **Status**  | IMPLEMENTED                                   |
+
+## Context
+
+The kbar command palette reads a build-time index at `public/search.json`
+that today contains only blog posts, so projects, the about page, and key
+static pages are undiscoverable. This plan expands the generated index to
+cover all content, emitting one English and one Italian entry per localized
+document (sharing a single URL), and wires a custom client `SearchProvider`
+that renders the new normalized entries correctly — the current default
+Pliny mapper cannot, because it assumes string titles and a `date`/`path`
+on every item.
+
+## Branch Strategy
+
+> **Before implementation, create a new branch from the repo's base
+> branch.** The implementer auto-detects the base in this priority
+> order: `develop` → `main` → `master` → `origin/HEAD`. The branch
+> name is `feat/expand-search-index-all-content`.
+>
+> Reference command (the implementer adapts to the detected base):
+>
+> ```bash
+> git checkout <base> && git pull --ff-only && git checkout -b feat/expand-search-index-all-content
+> ```
+>
+> If the repo is not a git workspace, branch creation is skipped and
+> noted in the implementation report.
+
+## Commit Strategy
+
+All commits follow [Conventional Commits v1.0.0](https://www.conventionalcommits.org/en/v1.0.0/).
+
+Format: `<type>[(<scope>)]: <imperative description>`
+
+One commit per task. Each task in the Tasks section maps to exactly one
+commit.
+
+## Build & Test Commands
+
+| Action        | Command                                                                                                                                       |
+| ------------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
+| Build         | `npm run build` (runs `next build`, which triggers contentlayer `onSuccess` and regenerates `public/search.json`)                             |
+| Lint          | `npm run lint`                                                                                                                                |
+| Inspect index | `cat public/search.json \| node -e "let d='';process.stdin.on('data',c=>d+=c);process.stdin.on('end',()=>console.log(JSON.parse(d).length))"` |
+
+> The project has no unit-test framework configured (no jest/vitest in
+> `package.json`). Verification is done via the build output and manual
+> inspection of `public/search.json` plus the running dev server
+> (`npm run dev`). Tasks below describe concrete inspection checks in lieu
+> of automated tests.
+
+## Tasks
+
+### Task 1: Add search-index generator helper for all content `[M]`
+
+**Goal**: Create a `lib/generateSearchIndex.ts` helper that builds a
+normalized, per-language, multi-type list of search entries and writes it
+to `public/search.json`.
+
+**Files**:
+
+| File                         | Action | Description                                 |
+| ---------------------------- | ------ | ------------------------------------------- |
+| `lib/generateSearchIndex.ts` | create | Builds and writes the expanded search index |
+
+**Reuse**:
+
+| File                             | What to reuse                                                                                                  |
+| -------------------------------- | -------------------------------------------------------------------------------------------------------------- |
+| `lib/generateProjectTagData.ts`  | Pattern: exported async fn, `writeFileSync`, iterate docs                                                      |
+| `contentlayer.config.ts` (66–77) | Existing guard on `provider === 'kbar'` + `searchDocumentsPath` and `public/${path.basename(...)}` target path |
+| `data/siteMetadata.js`           | `search.provider`, `search.kbarConfig.searchDocumentsPath`                                                     |
+
+**Steps**:
+
+1. Export `async function createSearchIndex(allBlogs, allProjects, authors)`.
+2. Keep the existing guard: only proceed when
+   `siteMetadata?.search?.provider === 'kbar'` and
+   `siteMetadata.search.kbarConfig.searchDocumentsPath` is set. Write to
+   `public/${path.basename(searchDocumentsPath)}` (matches current behavior
+   and honors `BASE_PATH`).
+3. Define an entry shape: `{ id, title, summary, type, url }` where `title`
+   and `summary` are **plain strings** (already localized) and `type` is a
+   section label (`'Blog' | 'Project' | 'Page'`).
+4. Add a helper `emitLocalized(doc, url, type)` that pushes two entries:
+   one from the `en` fields and one from the `it` fields. Fall back to the
+   other language when one side is missing (e.g. `title.it ?? title.en`) so
+   no empty title/URL is emitted (edge case: missing localized field).
+   Give each entry a unique `id` (e.g. `${url}#en` / `${url}#it`).
+5. Explicitly filter drafts: skip any blog/project with `draft === true`.
+   (Do not rely on `allCoreContent`'s draft filter, which only applies when
+   `NODE_ENV === 'production'`.)
+6. Map content types:
+   - Blogs → `type: 'Blog'`, `url: '/' + doc.path` (path is `blog/<slug>`).
+   - Projects → `type: 'Project'`, `url: '/projects/' + doc.slug`.
+   - About → `type: 'Page'`, `url: '/about'`, built from the author doc
+     (`data/authors/default.mdx`). Use the author `name` for the title
+     (author has no `{en,it}` title) with a short localized summary derived
+     from `occupation`/`company` or a fixed localized string.
+7. Append hand-authored static-page entries (see Task 2 — import from the
+   shared definition) for `/contact`, `/projects`, `/blog`, each with en+it
+   entries and `type: 'Page'`.
+8. Serialize with `JSON.stringify(entries)` and `writeFileSync`. Log
+   `'Local search index generated...'` to preserve existing console output.
+
+**Tests**:
+
+- After wiring (Task 3) and `npm run build`, inspect `public/search.json`:
+  every entry has string `title`, string `summary`, a `type`, and a `url`
+  starting with `/`. No entry has an object-valued `title`.
+
+**Acceptance criteria covered**: entry fields (title/type/summary/url),
+per-language double entries, draft exclusion, missing-localized fallback,
+provider guard.
+
+**Commit**: `feat(search): add expanded multi-content search index generator`
+
+---
+
+### Task 2: Define shared static-page search entries `[S]`
+
+**Goal**: Provide a single source of truth for the hand-authored static
+pages (`/contact`, `/projects`, `/blog`) with localized titles/summaries,
+importable by the generator.
+
+**Files**:
+
+| File                       | Action | Description                                                                                                 |
+| -------------------------- | ------ | ----------------------------------------------------------------------------------------------------------- |
+| `lib/searchStaticPages.ts` | create | Exports an array of `{ url, type, title:{en,it}, summary:{en,it} }` for contact, projects index, blog index |
+
+**Reuse**:
+
+| File                                                                 | What to reuse                                                    |
+| -------------------------------------------------------------------- | ---------------------------------------------------------------- |
+| `app/contact/page.tsx`, `app/projects/page.tsx`, `app/blog/page.tsx` | Confirm existing route paths and page titles for accurate labels |
+
+**Steps**:
+
+1. Export `staticSearchPages` = array of three objects:
+   `{ url: '/contact', type: 'Page', title: { en: 'Contact', it: 'Contatti' }, summary: {...} }`,
+   `{ url: '/projects', type: 'Page', title: { en: 'Projects', it: 'Progetti' }, ... }`,
+   `{ url: '/blog', type: 'Page', title: { en: 'Blog', it: 'Blog' }, ... }`.
+2. Keep summaries short and localized (one line each). Verify wording
+   against the actual pages.
+3. This module is plain data (no contentlayer import) so it is safe to
+   import from `lib/generateSearchIndex.ts` at build time.
+
+**Tests**:
+
+- `public/search.json` (after build) contains entries with URLs `/contact`,
+  `/projects`, and `/blog`, each present in both languages.
+
+**Acceptance criteria covered**: static pages indexed with correct URLs;
+per-language entries for static pages.
+
+**Commit**: `feat(search): add static page entries for search index`
+
+---
+
+### Task 3: Wire the generator into contentlayer onSuccess `[S]`
+
+**Goal**: Replace the inline blog-only `createSearchIndex` with the new
+helper, passing blogs, projects, and the author document.
+
+**Files**:
+
+| File                     | Action | Description                                                                        |
+| ------------------------ | ------ | ---------------------------------------------------------------------------------- |
+| `contentlayer.config.ts` | modify | Remove inline `createSearchIndex`; import and call the new helper from `onSuccess` |
+
+**Reuse**:
+
+| File                               | What to reuse                                                                                                        |
+| ---------------------------------- | -------------------------------------------------------------------------------------------------------------------- |
+| `contentlayer.config.ts` (316–321) | Existing `onSuccess` that destructures `importData()` and already calls `createBlogTagCount`/`createProjectTagCount` |
+
+**Steps**:
+
+1. Delete the inline `createSearchIndex(allBlogs)` function (lines ~66–77)
+   and the now-unused imports if they become unused (`allCoreContent`,
+   `sortPosts` — confirm before removing; keep any still referenced).
+2. Import the new helper:
+   `import { createSearchIndex } from './lib/generateSearchIndex'`.
+3. In `onSuccess`, destructure `allBlogs, allProjects, allAuthors` (or the
+   correct generated name for authors — verify against
+   `contentlayer/generated`) from `await importData()`.
+4. Call `await createSearchIndex(allBlogs, allProjects, allAuthors)` after
+   the existing tag-count calls.
+
+**Tests**:
+
+- `npm run build` completes without errors and logs
+  `Local search index generated...`.
+- `public/search.json` now contains Blog, Project, and Page entries.
+
+**Acceptance criteria covered**: index includes all content types; blog
+entries preserved.
+
+**Commit**: `refactor(search): generate index from all content in onSuccess`
+
+---
+
+### Task 4: Add custom client SearchProvider for the new index shape `[M]`
+
+**Goal**: Replace the generic Pliny `SearchProvider` in `app/layout.tsx`
+with a custom wrapper built on `KBarSearchProvider` that maps the new flat
+entries into kbar actions and renders correctly.
+
+**Files**:
+
+| File                                   | Action | Description                                                                 |
+| -------------------------------------- | ------ | --------------------------------------------------------------------------- |
+| `components/search/SearchProvider.tsx` | create | `'use client'` wrapper using `KBarSearchProvider` + `onSearchDocumentsLoad` |
+| `app/layout.tsx`                       | modify | Import the local `SearchProvider` instead of `pliny/search`                 |
+
+**Reuse**:
+
+| File                                  | What to reuse                                                                          |
+| ------------------------------------- | -------------------------------------------------------------------------------------- |
+| `faq/customize-kbar-search.md`        | Reference implementation of a custom `KBarSearchProvider` with `onSearchDocumentsLoad` |
+| `data/siteMetadata.js`                | `search.kbarConfig.searchDocumentsPath` for the config                                 |
+| `node_modules/pliny/search/KBar.d.ts` | `KBarSearchProps` typing for `onSearchDocumentsLoad`                                   |
+
+**Steps**:
+
+1. Create `components/search/SearchProvider.tsx` with `'use client'`.
+2. Use `KBarSearchProvider` from `pliny/search/KBar`, `useRouter` from
+   `next/navigation`.
+3. Set `searchDocumentsPath` from
+   `siteMetadata.search.kbarConfig.searchDocumentsPath`.
+4. Implement `onSearchDocumentsLoad(json)` mapping each entry to a kbar
+   action: `{ id, name: entry.title, keywords: entry.summary || '',
+section: entry.type, subtitle: entry.summary, perform: () =>
+router.push(entry.url) }`. Because `url` is already absolute (`/...`),
+   push it directly (do not prepend `/`).
+5. Optionally add `defaultActions` for Homepage (`/`) to preserve baseline
+   navigation — keep minimal; not required by spec.
+6. In `app/layout.tsx`, replace
+   `import { SearchProvider, SearchConfig } from 'pliny/search'` and the
+   `<SearchProvider searchConfig={...}>` usage with the new local
+   `SearchProvider` wrapping `<Layout>`. Remove the now-unused
+   `SearchConfig` import if nothing else uses it.
+
+**Tests**:
+
+- Run `npm run dev`, open the palette (Ctrl/Cmd-K), and verify:
+  results show readable localized titles (not `[object Object]`), grouped
+  by section (`Blog`/`Project`/`Page`); searching a project name, an
+  Italian summary term, and "about"/"contact" surfaces the right entries;
+  selecting a result navigates to the correct URL.
+
+**Acceptance criteria covered**: entries render with localized title +
+type + summary; selecting a result navigates correctly; both languages
+searchable; no blog regression.
+
+**Commit**: `feat(search): render expanded search index via custom kbar provider`
+
+---
+
+**Task ordering**: Task 2 has no dependencies. Task 1 depends on Task 2
+(imports `staticSearchPages`). Task 3 depends on Task 1. Task 4 depends on
+the index shape defined in Task 1 (field names must match) but touches only
+client code, so it can be developed in parallel once the entry shape from
+Task 1 is fixed; verify end-to-end after Task 3. Recommended order:
+2 → 1 → 3 → 4.
+
+## Edge Cases & Error Handling
+
+- **Missing localized field**: `emitLocalized` falls back to the other
+  language (`?? `) so titles/URLs are never empty (Task 1).
+- **Draft content**: explicitly filtered by `draft === true` in the
+  generator, independent of `NODE_ENV` (Task 1).
+- **Empty summary**: entry still emitted with title/type/url; `keywords`
+  and `subtitle` default to `''` in the mapper (Tasks 1, 4).
+- **Duplicate-looking en/it results**: accepted; both share one URL and
+  resolve to the same page (Tasks 1, 4).
+- **Search provider disabled / non-kbar**: generator guard skips writing;
+  no file emitted (Task 1).
+- **URL already absolute**: mapper pushes `entry.url` directly rather than
+  prepending `/` (Task 4), unlike the default Pliny mapper.
+
+## Verification
+
+1. Run `npm run build`; confirm it logs `Local search index generated...`
+   and completes without errors.
+2. Inspect `public/search.json`: confirm entries for blog posts, all
+   non-draft projects (`/projects/<slug>`), the about page (`/about`), and
+   the three static pages (`/contact`, `/projects`, `/blog`); confirm every
+   localized document has both an en and an it entry; confirm all `title`
+   and `summary` values are plain strings and all `url` values start with
+   `/`.
+3. Run `npm run dev`, open the command palette, and verify localized
+   titles render, results are grouped by section, queries in English and
+   Italian both match, and selecting results navigates to the correct
+   pages (including an existing blog post — no regression).
+4. Run `npm run lint` to confirm no lint errors in the new/changed files.

--- a/plans/language-filtered-search-results.md
+++ b/plans/language-filtered-search-results.md
@@ -1,0 +1,202 @@
+# Plan: Filter Search Results by Active Language
+
+| Field       | Value                                     |
+| ----------- | ----------------------------------------- |
+| **Title**   | Filter Search Results by Active Language  |
+| **Spec**    | specs/language-filtered-search-results.md |
+| **Type**    | feature                                   |
+| **Branch**  | feat/language-filtered-search-results     |
+| **Created** | 2026-08-05 03:00:00                       |
+| **Status**  | IMPLEMENTED                               |
+
+## Context
+
+The command palette currently loads both the English and Italian entry for
+every document, so a query in one language surfaces the other language's
+result and pages appear twice. This plan scopes results to the active UI
+language by tagging each index entry with an explicit `lang` field and
+filtering entries in the custom `SearchProvider` using the existing
+`useLanguage()` context, remounting the kbar provider on language change so
+the action set rebuilds.
+
+## Branch Strategy
+
+> **Before implementation, create a new branch from the repo's base
+> branch.** The implementer auto-detects the base in this priority
+> order: `develop` → `main` → `master` → `origin/HEAD`. The branch
+> name is `feat/language-filtered-search-results`.
+>
+> Reference command (the implementer adapts to the detected base):
+>
+> ```bash
+> git checkout <base> && git pull --ff-only && git checkout -b feat/language-filtered-search-results
+> ```
+>
+> If the repo is not a git workspace, branch creation is skipped and
+> noted in the implementation report.
+
+> Note: the predecessor spec `expand-search-index-all-content` was
+> implemented on branch `feat/expand-search-index-all-content` and may not
+> yet be merged into the base. If that work is not on the detected base,
+> branch this work from `feat/expand-search-index-all-content` instead, so
+> `lib/generateSearchIndex.ts` and `components/search/SearchProvider.tsx`
+> (created there) are present. The implementer should confirm those two
+> files exist on the chosen base before starting.
+
+## Commit Strategy
+
+All commits follow [Conventional Commits v1.0.0](https://www.conventionalcommits.org/en/v1.0.0/).
+
+Format: `<type>[(<scope>)]: <imperative description>`
+
+One commit per task. Each task in the Tasks section maps to exactly one
+commit.
+
+## Build & Test Commands
+
+| Action        | Command                                                                                           |
+| ------------- | ------------------------------------------------------------------------------------------------- | --- | ----------------- |
+| Build         | `npm run build` (runs `next build`; contentlayer `onSuccess` regenerates `public/search.json`)    |
+| Lint          | `npm run lint`                                                                                    |
+| Inspect index | `node -e "const j=require('./public/search.json'); console.log(j.length, j.every(e=>e.lang==='en' |     | e.lang==='it'))"` |
+
+> The project has no unit-test framework configured (no jest/vitest in
+> `package.json`). Verification is via the build output, inspecting
+> `public/search.json`, and manual exercise of the palette in
+> `npm run dev`. Tasks describe concrete inspection checks in lieu of
+> automated tests.
+>
+> Node is provided via nvm; if `node`/`npm` are not on PATH, load it first:
+> `export NVM_DIR="$HOME/.nvm"; . "$NVM_DIR/nvm.sh"; nvm use 22`.
+
+## Tasks
+
+### Task 1: Add explicit `lang` field to each search index entry `[S]`
+
+**Goal**: Emit a `lang: 'en' | 'it'` property on every entry written to
+`public/search.json`, so the client can filter without parsing the `id`.
+
+**Files**:
+
+| File                         | Action | Description                                                        |
+| ---------------------------- | ------ | ------------------------------------------------------------------ |
+| `lib/generateSearchIndex.ts` | modify | Add `lang` to the `SearchEntry` type and set it in `emitLocalized` |
+
+**Reuse**:
+
+| File                         | What to reuse                                                                                   |
+| ---------------------------- | ----------------------------------------------------------------------------------------------- |
+| `lib/generateSearchIndex.ts` | Existing `LOCALES` loop and `emitLocalized` helper — `locale` is already in scope per iteration |
+
+**Steps**:
+
+1. Extend the exported `SearchEntry` type (lines 10–16) with
+   `lang: Locale` (i.e. `'en' | 'it'`).
+2. In `emitLocalized` (lines 44–52), add `lang: locale` to the pushed
+   entry object. No other call sites need to change — every entry flows
+   through this helper (blogs, projects, about, static pages).
+3. Leave the `id` format (`${url}#${locale}`) unchanged for stability; the
+   `lang` field is now the source of truth for filtering.
+
+**Tests**:
+
+- After `npm run build`, inspect `public/search.json`: every entry has a
+  `lang` of `'en'` or `'it'`; the en/it split is even (roughly half each),
+  and each URL still has exactly one `en` and one `it` entry.
+
+**Acceptance criteria covered**: explicit `lang` field on every entry;
+build still generates `search.json`.
+
+**Commit**: `feat(search): tag search index entries with language`
+
+---
+
+### Task 2: Filter palette results by active language `[M]`
+
+**Goal**: Make `SearchProvider` show only entries matching the active UI
+language, and rebuild the kbar action set when the language toggles.
+
+**Files**:
+
+| File                                   | Action | Description                                                                           |
+| -------------------------------------- | ------ | ------------------------------------------------------------------------------------- |
+| `components/search/SearchProvider.tsx` | modify | Read `lang` via `useLanguage()`, filter entries by `lang`, key the provider on `lang` |
+
+**Reuse**:
+
+| File                                   | What to reuse                                                                      |
+| -------------------------------------- | ---------------------------------------------------------------------------------- | ------------------------------------ |
+| `contexts/LanguageContext.tsx`         | `useLanguage()` hook → `{ lang }` (`'en'                                           | 'it'`), already exported at line 184 |
+| `components/common/LanguageToggle.tsx` | Reference for the mounted-guard pattern used elsewhere to avoid hydration mismatch |
+| `components/search/SearchProvider.tsx` | Existing `onSearchDocumentsLoad` mapping and `SearchEntry` type                    |
+
+**Steps**:
+
+1. Add `'use client'` is already present. Import `useLanguage` from
+   `@/contexts/LanguageContext`.
+2. Extend the local `SearchEntry` type with `lang: 'en' | 'it'` to match
+   the generated shape from Task 1.
+3. Inside the component, call `const { lang } = useLanguage()`.
+4. In `onSearchDocumentsLoad`, filter before mapping:
+   `json.filter((entry) => entry.lang === lang).map(...)`. Entries whose
+   `lang` does not equal the active language (including any unexpected
+   value) are dropped, so a mismatched-language query yields no results.
+5. Add `key={lang}` to the `KBarSearchProvider` element so that toggling
+   the language remounts it and re-runs `onSearchDocumentsLoad` against the
+   new `lang`. (The index is ~22 entries, so remount cost is negligible.)
+6. Confirm the mapped action fields are unchanged (id, name=title,
+   keywords=summary, section=type, subtitle=summary,
+   perform=router.push(url)), so visible results keep localized title,
+   type label, summary, and correct navigation.
+
+**Tests**:
+
+- `npm run dev`, open the palette (Cmd/Ctrl-K):
+  - With language = en: `i built` → returns the English "I built two
+    robots…" entry; the Italian counterpart is absent. `ho costruito`
+    → no results.
+  - Toggle to it (without reloading): `ho costruito` → returns only the
+    Italian entry; `i built` → no results.
+  - Each visible result shows a title, section (Blog/Project/Page), and
+    summary, and selecting it navigates to the correct URL.
+- `npm run lint` passes with no errors.
+
+**Acceptance criteria covered**: reads active language via `useLanguage()`;
+only matching-`lang` entries mapped; en/it symmetric filtering; mismatched
+query returns nothing; language toggle updates results without reload;
+visible results retain title/type/summary/url; unknown-lang safety.
+
+**Commit**: `feat(search): filter palette results by active language`
+
+---
+
+**Task ordering**: Task 2 depends on the `lang` field emitted by Task 1
+(the client filter reads `entry.lang`). Implement Task 1 first, rebuild so
+`public/search.json` carries `lang`, then Task 2. End-to-end verification
+happens after Task 2.
+
+## Edge Cases & Error Handling
+
+- **Missing localized field**: unchanged — `localize()` still falls back to
+  the other language's text, and the entry keeps the `lang` of its slot, so
+  it appears only under that language (Task 1).
+- **Initial render / hydration**: `useLanguage()` resolves to `en` on first
+  paint and corrects after mount, consistent with the rest of the site; the
+  palette reflects the resolved language once mounted (Task 2).
+- **Unknown / future `lang` value**: the strict equality filter
+  (`entry.lang === lang`) drops non-matching entries, so an unexpected
+  value yields an empty (not broken) palette (Task 2).
+- **Empty query**: kbar default behavior unchanged; only the candidate
+  action set is language-scoped (Task 2).
+
+## Verification
+
+1. Run `npm run build`; confirm it succeeds and logs
+   `Local search index generated...`.
+2. Inspect `public/search.json`: every entry has `lang` `'en'` or `'it'`;
+   each URL still has one `en` and one `it` entry.
+3. Run `npm run dev` and exercise the palette in both languages per the
+   Task 2 tests: correct-language queries match, cross-language queries
+   return nothing, toggling language flips the available results without a
+   page reload, and selecting a result navigates correctly.
+4. Run `npm run lint`; confirm no errors.

--- a/specs/expand-search-index-all-content.md
+++ b/specs/expand-search-index-all-content.md
@@ -1,0 +1,162 @@
+# Expand Site Search Index to Cover All Content
+
+| Field       | Value                                            |
+| ----------- | ------------------------------------------------ |
+| **Title**   | Expand Site Search Index to Cover All Content    |
+| **Type**    | feature                                          |
+| **Scope**   | search index generation (contentlayer.config.ts) |
+| **Created** | 2026-08-05 00:00:00                              |
+| **Status**  | IMPLEMENTED                                      |
+
+## Problem Statement
+
+The site's command palette (Pliny kbar `SearchProvider`, configured in
+`data/siteMetadata.js`) reads a static index generated at build to
+`public/search.json`. Today that index only contains blog posts, so
+projects and the about page are not discoverable via search. Visitors
+who search for a project name, a technology used in a project, or
+information about the author get no results, which makes a growing part
+of the site invisible to the primary discovery affordance.
+
+The site is also bilingual (`{ en, it }` frontmatter for
+`title`/`summary`/`tags`) with no language-specific URLs, so the index
+must decide how to represent both languages against a single URL per page.
+
+## Current Behavior
+
+- `contentlayer.config.ts` defines a `createSearchIndex(allBlogs)`
+  helper that, when `siteMetadata.search.provider === 'kbar'` and a
+  `searchDocumentsPath` is set, writes
+  `public/search.json` from `allCoreContent(sortPosts(allBlogs))`.
+- `onSuccess` calls `createSearchIndex(allBlogs)` — **only blog posts**
+  are passed in.
+- As a result, `public/search.json` contains only blog documents.
+  Projects (`data/projects/*.mdx` → `allProjects`), the about author
+  page (`data/authors/default.mdx`), and static routes
+  (`/contact`, `/projects`, `/blog`) are absent from search.
+- kbar renders each indexed document using its `title` and links via the
+  document's `path`/`url`. Blog documents resolve correctly because
+  their `path` maps to `/blog/<slug>`.
+
+## Desired Outcome
+
+`public/search.json` is generated from all indexable content so that the
+command palette surfaces:
+
+- **Blog posts** — unchanged from today, linking to `/blog/<slug>`.
+- **Projects** — every `data/projects/*.mdx`, linking to
+  `/projects/<slug>`.
+- **About page** — a single entry for `data/authors/default.mdx`,
+  linking to `/about`.
+- **Static pages** — hand-authored entries for the contact page
+  (`/contact`), the projects index (`/projects`), and the blog index
+  (`/blog`).
+
+Each result carries a title, a type/section label, a summary subtitle,
+and the correct URL. Because there are no language-specific URLs, every
+localized document produces **two index entries** — one for English and
+one for Italian — both pointing at the same URL, so a query in either
+language finds the page.
+
+## Language Model
+
+- For every localized document (blog, project, about), emit **two search
+  entries**: one built from the `en` fields and one from the `it` fields.
+- Both entries for a document share the **same URL** (there are no
+  `/en` or `/it` routes).
+- The English entry uses `title.en` / `summary.en`; the Italian entry
+  uses `title.it` / `summary.it`. Tag labels follow the same per-language
+  split where tags are included.
+- Static-page entries (contact, projects index, blog index) likewise get
+  an English and an Italian entry, using the page's localized title and
+  a short localized description.
+
+## Result Shape
+
+Each entry in `search.json` contains:
+
+- **title** — the localized page/post/project title.
+- **type / section label** — a category such as `Blog`, `Project`, or
+  `Page`, so results are visually grouped/identifiable.
+- **summary** — the localized summary used as the result subtitle.
+- **url** — the canonical route for the content
+  (`/blog/<slug>`, `/projects/<slug>`, `/about`, `/contact`,
+  `/projects`, `/blog`).
+
+Full MDX body text is **not** indexed; matching is on
+title/summary/type (and tag labels where present).
+
+## Acceptance Criteria
+
+- [ ] After a build, `public/search.json` contains entries for blog
+      posts, projects, the about page, and the three static pages
+      (contact, projects index, blog index).
+- [ ] Every project in `data/projects/*.mdx` (that is not a draft) is
+      represented, with URL `/projects/<slug>`.
+- [ ] The about page is represented with URL `/about`.
+- [ ] Static pages are represented with URLs `/contact`, `/projects`,
+      and `/blog`.
+- [ ] Each localized document (blog, project, about) produces two
+      entries — one English, one Italian — both pointing to the same URL.
+- [ ] Each entry includes a localized title, a type/section label, a
+      localized summary subtitle, and a correct URL.
+- [ ] Selecting any result in the kbar palette navigates to the correct
+      page.
+- [ ] Content flagged `draft: true` (blog or project) is excluded from
+      the index.
+- [ ] Existing blog search results continue to work with the same URLs
+      and titles as before (no regression).
+
+## Edge Cases & Error Handling
+
+- **Missing localized field**: if a document lacks `it` (or `en`)
+  title/summary, the corresponding entry should fall back gracefully
+  (e.g. reuse the available language) rather than emit an empty/broken
+  result.
+- **Draft content**: excluded from the index entirely; no entry in
+  either language.
+- **Duplicate-looking results**: because en/it entries share a URL, a
+  user searching a term present in both languages may see two similar
+  results — this is accepted, both resolve to the same page.
+- **Search provider disabled or non-kbar**: index generation remains
+  guarded by the existing `provider === 'kbar'` and `searchDocumentsPath`
+  checks; when not applicable, nothing is written.
+- **Empty summary**: entries with no summary should still index cleanly
+  with just title + type + URL.
+
+## Dependencies & Constraints
+
+- Index generation happens in `contentlayer.config.ts` `onSuccess`,
+  which already receives `allBlogs` and `allProjects` from
+  `importData()`. The about author is available via the `Authors`
+  document type; static-page entries have no MDX source and must be
+  authored inline.
+- Must honor `siteMetadata.search.kbarConfig.searchDocumentsPath` and the
+  `BASE_PATH` prefix (the config already prefixes `search.json` with
+  `process.env.BASE_PATH`).
+- Output must remain compatible with what Pliny's kbar
+  `SearchProvider` expects to read from `public/search.json`.
+- No language-specific routing exists; URLs are single-locale.
+
+## Out of Scope
+
+- Adding language-specific URLs or i18n routing.
+- Indexing full MDX body text / full-text search.
+- Switching search providers (e.g. Algolia) or changing the kbar UI.
+- Ranking, boosting, or fuzzy-match tuning beyond kbar defaults.
+- Generating tag-count or other auxiliary data files (handled elsewhere).
+
+## Notes
+
+- Current generator: `createSearchIndex(allBlogs)` in
+  `contentlayer.config.ts` (lines ~66–77 and the `onSuccess` call at
+  ~316–321) writes only blog content.
+- Relevant routes confirmed present: `app/blog/[...slug]/page.tsx`,
+  `app/projects/[slug]/page.tsx`, `app/about/page.tsx`,
+  `app/contact/page.tsx`, `app/projects/page.tsx`, `app/blog/page.tsx`.
+- Blog and Project document types already expose `titleEn`/`summaryEn`
+  (and blog has `titleIt`/`summaryIt`) computed fields, which may help
+  build the per-language entries.
+- Open question for implementation: exact type-label wording
+  (`Blog`/`Project`/`Page` vs. localized labels) and whether tag labels
+  are added to the searchable text — can be decided during planning.

--- a/specs/language-filtered-search-results.md
+++ b/specs/language-filtered-search-results.md
@@ -1,0 +1,111 @@
+# Filter Search Results by Active Language
+
+| Field       | Value                                          |
+| ----------- | ---------------------------------------------- |
+| **Title**   | Filter Search Results by Active Language       |
+| **Type**    | feature                                        |
+| **Scope**   | kbar search provider + search index generation |
+| **Created** | 2026-08-05 02:30:00                            |
+| **Status**  | IMPLEMENTED                                    |
+
+## Problem Statement
+
+The command palette now indexes all content in both languages, emitting
+one English and one Italian entry per document (see
+`specs/expand-search-index-all-content.md`). Because both entries are
+always loaded, a search shows results in the language the query was _not_
+written in, and duplicate-looking results appear for the same page. Users
+expect search to respect the language they have actively selected: an
+English speaker searching English terms should not see Italian entries,
+and vice versa.
+
+## Current Behavior
+
+- `public/search.json` contains two entries per localized document — one
+  built from `en` fields, one from `it` fields — distinguished by an `id`
+  suffix (`…#en` / `…#it`).
+- `components/search/SearchProvider.tsx` maps **all** entries into kbar
+  actions in `onSearchDocumentsLoad`, regardless of the active UI language.
+- Result: with language set to English, typing an Italian phrase can still
+  match the Italian entry; every page can surface as two near-identical
+  results.
+
+## Desired Outcome
+
+Search results are limited to the currently selected UI language:
+
+- With language = **en**, searching `i built` returns the blog entry
+  "I built two robots…"; the Italian counterpart is **not** shown.
+- With language = **it**, searching `ho costruito` returns only the
+  Italian blog entry.
+- With language = **en**, searching `ho costruito` returns **no results**
+  (the Italian entry is not loaded into the palette).
+- Toggling the language updates which results the palette can return,
+  without a full page reload.
+
+## Acceptance Criteria
+
+- [ ] Each entry in `public/search.json` carries an explicit
+      `lang` field (`'en' | 'it'`) rather than encoding language only in
+      the `id`.
+- [ ] `components/search/SearchProvider.tsx` reads the active language via
+      the existing `useLanguage()` hook (`@/contexts/LanguageContext`).
+- [ ] Only entries whose `lang` matches the active language are mapped into
+      kbar actions.
+- [ ] With language = en, an English-only query matches the English entry
+      and never the Italian one; an Italian-only query returns no results.
+- [ ] With language = it, the symmetric behavior holds.
+- [ ] Switching language while browsing (without reloading the page)
+      changes which language's results the palette returns.
+- [ ] Each visible result still shows a localized title, a type/section
+      label, a summary subtitle, and navigates to the correct URL.
+- [ ] The build still generates `public/search.json` and the site builds
+      and lints cleanly.
+
+## Edge Cases & Error Handling
+
+- **Missing localized field**: entries already fall back to the other
+  language's text at generation time; a fallback entry still carries the
+  `lang` of the slot it fills, so it appears only under that language.
+- **Initial render / hydration**: the language context defaults to `en`
+  on first paint and corrects after mount; the palette should reflect the
+  resolved language once mounted (accept an initial `en` view before
+  hydration, consistent with the rest of the site).
+- **Unknown / future language value**: if `lang` is neither `en` nor `it`,
+  the palette shows no entries rather than crashing.
+- **Empty query**: unchanged kbar default behavior; only the candidate
+  action set is language-scoped.
+
+## Dependencies & Constraints
+
+- Depends on the search index produced by
+  `specs/expand-search-index-all-content.md` (already implemented).
+- Language state is a client-only React Context
+  (`@/contexts/LanguageContext`, `useLanguage()` → `{ lang, t, switchLang }`),
+  persisted to `localStorage` (`lightstimulus.lang`). There are no
+  language-specific URLs.
+- `SearchProvider` is already a client component and sits inside the
+  `LanguageProvider` tree, so it can consume `useLanguage()`.
+- kbar builds its action list when the index loads; the provider must be
+  keyed to the active language (e.g. `key={lang}`) so the action set
+  rebuilds when the language toggles. The index is small (~22 entries), so
+  a remount on toggle is acceptable.
+
+## Out of Scope
+
+- Adding language-specific URLs or i18n routing.
+- Browser/Accept-Language auto-detection.
+- Cross-language "did you mean" or fallback results when a query has no
+  match in the active language (a mismatched query simply returns nothing).
+- Full-text/body search or ranking changes.
+- Reworking the language selection mechanism itself.
+
+## Notes
+
+- Active language read path (client): `useLanguage()` from
+  `@/contexts/LanguageContext` returns `lang: 'en' | 'it'`.
+- Chosen implementation approach: filter in `onSearchDocumentsLoad` by the
+  active `lang` and remount the `KBarSearchProvider` on language change via
+  a `key={lang}` prop (pragmatic given the tiny index).
+- The `lang` field on each index entry is added in
+  `lib/generateSearchIndex.ts` where entries are emitted per locale.


### PR DESCRIPTION
Expand the build-time search index (public/search.json) to cover blog posts, projects, the about page, and static pages instead of only blog posts, emitting one English and one Italian entry per document. Add a custom kbar SearchProvider that renders the normalized entries and scopes results to the active UI language via the LanguageContext.

- lib/generateSearchIndex.ts: build per-language, multi-type entries with an explicit lang field; exclude drafts; localized fallback
- lib/searchStaticPages.ts: localized entries for /contact, /projects, /blog
- contentlayer.config.ts: generate the index from blogs, projects, authors
- components/search/SearchProvider.tsx: custom kbar provider filtering by active language, keyed on lang to rebuild on toggle
- components/common/Layout.tsx, app/layout.tsx: nest SearchProvider inside LanguageProvider so it reads the real active language